### PR TITLE
:fireworks: Updates maintenance/license year to 2025

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2024 Franck Nijhof
+Copyright (c) 2024-2025 Franck Nijhof
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ our [GitHub Repository][repository].
 
 MIT License
 
-Copyright (c) 2024 Franck Nijhof
+Copyright (c) 2024-2025 Franck Nijhof
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -112,7 +112,7 @@ SOFTWARE.
 [i386-shield]: https://img.shields.io/badge/i386-no-red.svg
 [issue]: https://github.com/hassio-addons/addon-sonarr/issues
 [license-shield]: https://img.shields.io/github/license/hassio-addons/addon-sonarr.svg
-[maintenance-shield]: https://img.shields.io/maintenance/yes/2024.svg
+[maintenance-shield]: https://img.shields.io/maintenance/yes/2025.svg
 [project-stage-shield]: https://img.shields.io/badge/project%20stage-experimental-yellow.svg
 [reddit]: https://reddit.com/r/homeassistant
 [releases-shield]: https://img.shields.io/github/release/hassio-addons/addon-sonarr.svg

--- a/sonarr/.README.j2
+++ b/sonarr/.README.j2
@@ -58,7 +58,7 @@ If you are more interested in stable releases of our add-ons:
 [discord]: https://discord.gg/c5DvZ4e
 [forum-shield]: https://img.shields.io/badge/community-forum-brightgreen.svg
 [forum]: https://community.home-assistant.io/t/?u=frenck
-[maintenance-shield]: https://img.shields.io/maintenance/yes/2024.svg
+[maintenance-shield]: https://img.shields.io/maintenance/yes/2025.svg
 [project-stage-shield]: https://img.shields.io/badge/project%20stage-experimental-yellow.svg
 [release-shield]: https://img.shields.io/badge/version-{{ version }}-blue.svg
 [release]: {{ repo }}/tree/{{ version }}

--- a/sonarr/DOCS.md
+++ b/sonarr/DOCS.md
@@ -69,7 +69,7 @@ check [the contributor's page][contributors].
 
 MIT License
 
-Copyright (c) 2024 Franck Nijhof
+Copyright (c) 2024-2025 Franck Nijhof
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
# Proposed Changes

Happy New Year 🥂 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated copyright years from "2024" to "2024-2025" in LICENSE.md, README.md, sonarr/DOCS.md
	- Updated maintenance shield URL to reflect year 2025 in README.md and sonarr/.README.j2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->